### PR TITLE
include LICENSE, README.md; use .tar.xz; use .zip on Windows

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,13 +12,15 @@ builds:
     - amd64
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
-    files:
-    - none*
     replacements:
       darwin: Darwin
       linux: Linux
       windows: Windows
       amd64: x86_64
+    format: tar.xz
+    format_overrides:
+      - goos: windows
+        format: zip
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
This change to the `.goreleaser.yml` does the following:

* includes the `dns` binary as well as your `README.md` and `LICENSE` files in the `Release` section
* use `.tar.xz` instead of `.tar.gz` for better compression and smaller downloads
* use `.zip` on Windows since this file type can be opened by File Explorer without any additional third-party software
